### PR TITLE
v2023.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4"
+        "php": ">=8.0"
     },
     "autoload": {
         "files": ["g3-utilities.php"]

--- a/g3-utilities.php
+++ b/g3-utilities.php
@@ -3,13 +3,13 @@
 Plugin Name: G3 Utilities
 Plugin URI: https://www.goodglamm.com/
 Description: Collection of utility code/libraries for use with WordPress plugins/themes.
-Version: 2022.2
+Version: 2023.1
 Author: Good Glamm Group Engineering, Amit Gupta
 License: GPL v2
 */
 
 define( 'G3_UTILITIES_ROOT', __DIR__ );
-define( 'G3_UTILITIES_VERSION', '2022.2' );
+define( 'G3_UTILITIES_VERSION', '2023.1' );
 
 function g3_utilities_loader() : void {
 	require_once G3_UTILITIES_ROOT . '/dependencies.php';

--- a/g3-utilities.php
+++ b/g3-utilities.php
@@ -3,13 +3,13 @@
 Plugin Name: G3 Utilities
 Plugin URI: https://www.goodglamm.com/
 Description: Collection of utility code/libraries for use with WordPress plugins/themes.
-Version: 1.0.0
+Version: 2022.2
 Author: Good Glamm Group Engineering, Amit Gupta
 License: GPL v2
 */
 
 define( 'G3_UTILITIES_ROOT', __DIR__ );
-define( 'G3_UTILITIES_VERSION', '1.0.0' );
+define( 'G3_UTILITIES_VERSION', '2022.2' );
 
 function g3_utilities_loader() : void {
 	require_once G3_UTILITIES_ROOT . '/dependencies.php';

--- a/src/classes/class-autoloader.php
+++ b/src/classes/class-autoloader.php
@@ -42,7 +42,8 @@ class Autoloader {
 		if ( empty( $namespace_root ) || empty( $dir_path ) ) {
 			throw new ErrorException(
 				sprintf(
-					'%s: Both Namespace and Directory Path are required when registering Namespace for PHP class autoloading.',
+					/* translators: Placeholder is replaced by name of PHP class */
+					__( '%s: Both Namespace and Directory Path are required when registering Namespace for PHP class autoloading.', 'g3-utilities' ),
 					static::class
 				)
 			);

--- a/src/classes/class-g3.php
+++ b/src/classes/class-g3.php
@@ -28,6 +28,7 @@ class G3 {
 			Utilities\Files::class,
 			Utilities\Input::class,
 			Utilities\Strings::class,
+			Utilities\Time::class,
 		],
 	];
 

--- a/src/classes/interfaces/interface-utility-driver.php
+++ b/src/classes/interfaces/interface-utility-driver.php
@@ -25,7 +25,7 @@ interface Utility_Driver {
 	 *
 	 * @return object
 	 */
-	public static function get_instance() : object;
+	public static function get_instance( ...$args ) : self;
 
 }  // end interface
 

--- a/src/classes/interfaces/interface-utility-driver.php
+++ b/src/classes/interfaces/interface-utility-driver.php
@@ -23,9 +23,9 @@ interface Utility_Driver {
 	 * an instance of itself. It can either implement Singleton
 	 * pattern or Factory pattern.
 	 *
-	 * @return object
+	 * @return static
 	 */
-	public static function get_instance( ...$args ) : self;
+	public static function get_instance( ...$args ) : static;
 
 }  // end interface
 

--- a/src/classes/traits/trait-factory.php
+++ b/src/classes/traits/trait-factory.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Trait to implement the Factory pattern in a class
+ *
+ * @author Amit Gupta
+ *
+ * @since  2022-08-04
+ */
+
+namespace G3\Utilities\Traits;
+
+trait Factory {
+
+	/**
+	 * Method to return a new object of the
+	 * current class.
+	 *
+	 * This is a variadic method which is able to accept
+	 * unspecified number of arguments. All of those arguments
+	 * are passed to the constructor of the class using this Trait
+	 * as individual arguments. Whether those arguments
+	 * are used or not depends on the class using this Trait.
+	 *
+	 * This method has been set as final intentionally,
+	 * because it is not meant to be overridden.
+	 *
+	 * @param array $args
+	 *
+	 * @return static
+	 */
+	final public static function get_instance( ...$args ) : self {
+
+		return new static( ...$args );
+
+	}
+
+}  // end trait
+
+//EOF

--- a/src/classes/traits/trait-factory.php
+++ b/src/classes/traits/trait-factory.php
@@ -28,7 +28,7 @@ trait Factory {
 	 *
 	 * @return static
 	 */
-	final public static function get_instance( ...$args ) : self {
+	final public static function get_instance( ...$args ) : static {
 
 		return new static( ...$args );
 

--- a/src/classes/traits/trait-singleton.php
+++ b/src/classes/traits/trait-singleton.php
@@ -38,15 +38,23 @@ trait Singleton {
 	 * Method to return Singleton object of the
 	 * current class.
 	 *
+	 * This is a variadic method which is able to accept
+	 * unspecified number of arguments. All of those arguments
+	 * are passed to the constructor of the class using this Trait
+	 * as individual arguments. Whether those arguments
+	 * are used or not depends on the class using this Trait.
+	 *
 	 * This method has been set as final intentionally,
 	 * because it is not meant to be overridden.
 	 *
+	 * @param array $args
+	 *
 	 * @return object
 	 */
-	final public static function get_instance() : object {
+	final public static function get_instance( ...$args ) : self {
 
 		if ( ! is_a( static::$_instance, static::class ) ) {
-			static::$_instance = new static();
+			static::$_instance = new static( ...$args );
 		}
 
 		return static::$_instance;

--- a/src/classes/traits/trait-singleton.php
+++ b/src/classes/traits/trait-singleton.php
@@ -12,7 +12,7 @@ namespace G3\Utilities\Traits;
 trait Singleton {
 
 	/**
-	 * @var object
+	 * @var static
 	 */
 	protected static $_instance;
 
@@ -49,9 +49,9 @@ trait Singleton {
 	 *
 	 * @param array $args
 	 *
-	 * @return object
+	 * @return static
 	 */
-	final public static function get_instance( ...$args ) : self {
+	final public static function get_instance( ...$args ) : static {
 
 		if ( ! is_a( static::$_instance, static::class ) ) {
 			static::$_instance = new static( ...$args );

--- a/src/classes/utilities/class-arrays.php
+++ b/src/classes/utilities/class-arrays.php
@@ -25,6 +25,17 @@ class Arrays implements Utility_Driver {
 	}
 
 	/**
+	 * Wrapper around `empty()` because passing it directly to the `array_filter()` does not work.
+	 *
+	 * @param mixed $value
+	 *
+	 * @return bool
+	 */
+	protected function _is_value_empty( mixed $value ) : bool {
+		return empty( $value );
+	}
+
+	/**
 	 * Method to inject value in an array at a specific position.
 	 *
 	 * @param mixed $to_inject
@@ -33,7 +44,7 @@ class Arrays implements Utility_Driver {
 	 *
 	 * @return array
 	 */
-	public function inject( $to_inject, int $position, array $inject_into ) : array {
+	public function inject( mixed $to_inject, int $position, array $inject_into ) : array {
 
 		$before = [];
 		$after  = [];
@@ -76,6 +87,29 @@ class Arrays implements Utility_Driver {
 		);
 
 		return ( 1 > $numeric_indices );
+
+	}
+
+	/**
+	 * Method to check if the passed array has any empty index.
+	 * This works reliably only on single dimension arrays having string values
+	 * or values which can be evaluated using the `empty()` function.
+	 * That is why this method will not work with boolean FALSE, numeric zero, etc.
+	 *
+	 * @param array $data
+	 *
+	 * @return bool
+	 */
+	public function has_empty_indices( array $data ) : bool {
+
+		$empty_indices = count(
+			array_filter(
+				$data,
+				[ $this, '_is_value_empty' ]
+			)
+		);
+
+		return ( 0 < $empty_indices );
 
 	}
 

--- a/src/classes/utilities/class-files.php
+++ b/src/classes/utilities/class-files.php
@@ -10,6 +10,7 @@ namespace G3\Utilities\Utilities;
 
 use \G3\Utilities\Traits\Singleton;
 use \G3\Utilities\Interfaces\Utility_Driver;
+use \SplFileObject;
 
 class Files implements Utility_Driver {
 
@@ -38,6 +39,35 @@ class Files implements Utility_Driver {
 			&& file_exists( $file_path )
 			&& validate_file( $file_path ) === 0
 		);
+
+	}
+
+	/**
+	 * Method to get the number of lines in a file.
+	 * This works with large files as well because it does not load whole file in memory at once.
+	 *
+	 * @param string $file_path
+	 *
+	 * @return int
+	 */
+	public function get_number_of_lines( string $file_path ) : int {
+
+		$count = 0;
+
+		if ( ! $this->does_exist( $file_path ) ) {
+			return $count;
+		}
+
+		$file = new SplFileObject( $file_path, 'r' );
+
+		while ( ! $file->eof() ) {
+			$data   = $file->fread( 4096 );
+			$count += substr_count( $data, PHP_EOL );
+		}
+
+		unset( $file );
+
+		return $count;
 
 	}
 

--- a/src/classes/utilities/class-input.php
+++ b/src/classes/utilities/class-input.php
@@ -62,7 +62,8 @@ class Input implements Utility_Driver {
 			default:
 				throw new ErrorException(
 					sprintf(
-						'Called non-existent method %s::%s()',
+						/* translators: placeholders are class and method names */
+						__( 'Called non-existent method %s::%s()', 'g3-utilities' ),
 						static::class,
 						$name
 					)
@@ -124,7 +125,7 @@ class Input implements Utility_Driver {
 	 *
 	 * @codeCoverageIgnore
 	 */
-	public function filter( int $type, string $var_name, int $filter = FILTER_DEFAULT, $options = 0 ) {
+	public function filter( int $type, string $var_name, int $filter = FILTER_DEFAULT, array|int $options = 0 ) : mixed {
 
 		/*
 		 * filter_input() does not work on CLI, so let's isolate code
@@ -153,33 +154,14 @@ class Input implements Utility_Driver {
 		// We don't want this flagged by any phpcs ruleset
 		// phpcs:disable
 
-		switch ( $type ) {
-
-			case INPUT_GET:
-				$value_to_return = $_GET[ $var_name ] ?? null;
-				break;
-
-			case INPUT_POST:
-				$value_to_return = $_POST[ $var_name ] ?? null;
-				break;
-
-			case INPUT_COOKIE:
-				$value_to_return = $_COOKIE[ $var_name ] ?? null;
-				break;
-
-			case INPUT_SERVER:
-				$value_to_return = $_SERVER[ $var_name ] ?? null;
-				break;
-
-			case INPUT_ENV:
-				$value_to_return = $_ENV[ $var_name ] ?? null;
-				break;
-
-			default:
-				$value_to_return = null;
-				break;
-
-		}
+		$value_to_return = match ( $type ) {
+			INPUT_GET    => $_GET[ $var_name ] ?? null,
+			INPUT_POST   => $_POST[ $var_name ] ?? null,
+			INPUT_COOKIE => $_COOKIE[ $var_name ] ?? null,
+			INPUT_SERVER => $_SERVER[ $var_name ] ?? null,
+			INPUT_ENV    => $_ENV[ $var_name ] ?? null,
+			default      => null,
+		};
 
 		// phpcs:enable
 

--- a/src/classes/utilities/class-time.php
+++ b/src/classes/utilities/class-time.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Class to provide toolkit for manipulating time.
+ *
+ * @author Amit Gupta
+ *
+ * @since  2022-11-23
+ */
+namespace G3\Utilities\Utilities;
+
+use \G3\Utilities\Traits\Singleton;
+use \G3\Utilities\Interfaces\Utility_Driver;
+use \ErrorException;
+
+class Time implements Utility_Driver {
+
+	use Singleton;
+
+	/**
+	 * Method to get the driver name of the class
+	 *
+	 * @return string
+	 */
+	public static function get_driver_name() : string {
+		return 'time';
+	}
+
+	/**
+	 * Method to get human-readable time difference between two timestamps.
+	 *
+	 * @param int $from
+	 * @param int $to
+	 *
+	 * @return string
+	 *
+	 * @throws \ErrorException
+	 */
+	public function get_human_readable_diff( int $from, int $to ) : string {
+
+		if ( 0 > $from || 1 > $to ) {
+			throw new ErrorException(
+				sprintf(
+					/* translators: Placeholders are for class and method name. */
+					__( '%1$s::%2$s() expects valid timestamps to calculate difference.', 'g3-utilities' ),
+					static::class,
+					__FUNCTION__
+				)
+			);
+		}
+
+		$readable_diff = [];
+		$diff          = (int) ( $to - $from );
+
+		if ( WEEK_IN_SECONDS <= $diff ) {
+
+			$weeks = floor( $diff / WEEK_IN_SECONDS );
+			$diff  = ( $diff % WEEK_IN_SECONDS );
+
+			$readable_diff[] = sprintf(
+				/* translators: Time difference between two dates, in weeks. %s: Number of weeks. */
+				_n( '%s week', '%s weeks', $weeks, 'g3-utilities' ),
+				$weeks
+			);
+
+		}
+
+		if ( DAY_IN_SECONDS <= $diff ) {
+
+			$days = floor( $diff / DAY_IN_SECONDS );
+			$diff = ( $diff % DAY_IN_SECONDS );
+
+			$readable_diff[] = sprintf(
+				/* translators: Time difference between two dates, in days. %s: Number of days. */
+				_n( '%s day', '%s days', $days, 'g3-utilities' ),
+				$days
+			);
+
+		}
+
+		if ( HOUR_IN_SECONDS <= $diff ) {
+
+			$hours = floor( $diff / HOUR_IN_SECONDS );
+			$diff  = ( $diff % HOUR_IN_SECONDS );
+
+			$readable_diff[] = sprintf(
+				/* translators: Time difference between two dates, in hours. %s: Number of hours. */
+				_n( '%s hour', '%s hours', $hours, 'g3-utilities' ),
+				$hours
+			);
+
+		}
+
+		if ( MINUTE_IN_SECONDS <= $diff ) {
+
+			$minutes = floor( $diff / MINUTE_IN_SECONDS );
+			$diff    = ( $diff % MINUTE_IN_SECONDS );
+
+			$readable_diff[] = sprintf(
+				/* translators: Time difference between two dates, in minutes. %s: Number of minutes. */
+				_n( '%s minute', '%s minutes', $minutes, 'g3-utilities' ),
+				$minutes
+			);
+
+		}
+
+		if ( MINUTE_IN_SECONDS > $diff ) {
+
+			$seconds = $diff;
+
+			$readable_diff[] = sprintf(
+				/* translators: Time difference between two dates, in seconds. %s: Number of seconds. */
+				_n( '%s second', '%s seconds', $seconds, 'g3-utilities' ),
+				$seconds
+			);
+
+		}
+
+		$readable_diff = implode( ' ', $readable_diff );
+
+		return $readable_diff;
+
+	}
+
+}  // end class
+
+//EOF


### PR DESCRIPTION
-   Updated minimum PHP version requirement to v8.0
    -   Updated code for PHP 8.0
-   Changed version pattern to  `YYYY.XX`. Bumped version to  `2023.1`.
-   Updated error/exception messages to use i18n API of WordPress to make them translatable.
-   Changed signature of the  `get_instance()`  method in  `Singleton`  trait. In most cases these changes should not have any negative effects on existing code.
    -   `get_instance()`  is now a variadic method which is able to accept N number of arguments and then pass them as is to class constructor. This allows classes implementing the  `Singleton`  trait to be able to accept arguments at the time of instantiation.
    -   Changed return type of  `get_instance()`  to  `static`  to allow for more specific typecasting as class object than afforded by the generic  `object`  type hint.
-   Updated  `get_instance()`  signature in  `Utility_Driver`  interface to be in line with  `Singleton`  trait.
-   Added  `Factory`  trait to allow implementation of Factory pattern.
    -   Updated  `G3`  class to be able to accept both Singletons & Factories as drivers.
-   Updated  `arrays`  utility
    -   Added  `has_empty_indices()`  utility method.
-   Updated  `files`  utility
    -   Added  `get_number_of_lines()`  utility method.
-   Updated  `strings`  utility
    -   Added  `is_unicode()`  utility method.
    -   Added  `leadingslashit()`  utility method.
    -   Added  `get_sanitized_key()`  utility method.
    -   Added  `get_sanitized_with_links()`  utility method.
    -   Updated  `search_replace()`  to deal with both multibyte unicode & ASCII characters.
-   Added  `time`  utility.
